### PR TITLE
update all functions to use matching data arguments

### DIFF
--- a/R/get_hr.R
+++ b/R/get_hr.R
@@ -1,11 +1,17 @@
-#' Return hazard ratio for Polygenic Hazard Score
+#' Returns a hazard ratio for Polygenic Hazard Scores
+#' 
+#' This function calculate the hazard ratio.
+#' The data can either be provided as a data.frame with columns containing
+#' the phs, age, and status of each individual or separate vectors containing
+#' each of these values. The columns in `data` default to 'phs', 'age', and
+#' 'status', but any arbitrary column names can be used if named explicitly.
 #'
-#' @param phs a vector of polygenic hazard scores for subjects or a string specifying the column name in `data` containing these values
-#' @param age a vector of ages or a string specifying the column name in `data` containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation).
-#' @param status a vector of case-control status (0 = censored, 1 = event) or a string specifying the column name in `data` containing these values
-#' @param data an optional data.frame containing the variables phs, age, and status
-#' @param upper_quantile an optional vector specifying the upper quantile of the hazard ratio. The default is `0.80`. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., `c(0.80, 0.98)`).
-#' @param lower_quantile an optional vector specifying the lower quantile of the hazard ratio. The default is `0.20`. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., `c(0.3, 0.7)`).
+#' @param data an optional data.frame containing the variables for phs, age, and status
+#' @param phs an optional string specifying the column name in `data` containing the polygenic hazard score for each subject or the unquoted name of a vector containing these values. The default is "phs"
+#' @param age an optional string specifying the column name in `data` containing the age of each subject or the unquoted name of a vector containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation). The default is "age"
+#' @param status an optional string specifying the column name in `data` containing case-control status (0 = censored, 1 = event) or the unquoted name of a vector containing these values. The default is "status"
+#' @param upper_quantile an optional vector specifying the upper quantile of the hazard ratio. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., `c(0.80, 0.98)`). If only one value is provided, then the PHS scores between that number and Infinite are included. The default is `0.80`. 
+#' @param lower_quantile an optional vector specifying the lower quantile of the hazard ratio. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., `c(0.3, 0.7)`). If only one value is provided, then the PHS scores between -Infinite and that number are included. The default is `0.20`. 
 #' @param swc logical. if `TRUE` performs sample weight correction
 #' @param swc_popnumcases an optional integer specifying the number of cases in a reference population for sample weight correction. Required if swc = `TRUE`.
 #' @param swc_popnumcontrols an optional integer specifying the number of controls in a reference population for sample weight correction. Required if swc = `TRUE`.
@@ -14,10 +20,10 @@
 #' @examples
 #' HR80_20 <- get_hr(phs, age, status)
 #' @export
-get_hr <- function(phs, 
-                   age, 
-                   status, 
-                   data = NULL, 
+get_hr <- function(data = NULL, 
+                   phs = "phs", 
+                   age = "age", 
+                   status = "status", 
                    upper_quantile = 0.80, 
                    lower_quantile = 0.20, 
                    swc = FALSE, 

--- a/R/get_or.R
+++ b/R/get_or.R
@@ -7,10 +7,10 @@
 #' 'status', but any arbitrary column names can be used if named explicitly.
 #'
 #' @param data an optional data.frame containing the variables for phs, age, and status
-#' @param or_age an integer specifying the age at which the odds ratio should be calculated
 #' @param phs an optional string specifying the column name in `data` containing the polygenic hazard score for each subject or the unquoted name of a vector containing these values. The default is "phs"
 #' @param age an optional string specifying the column name in `data` containing the age of each subject or the unquoted name of a vector containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation). The default is "age"
 #' @param status an optional string specifying the column name in `data` containing case-control status (0 = censored, 1 = event) or the unquoted name of a vector containing these values. The default is "status"
+#' @param or_age an integer specifying the age at which the odds ratio should be calculated
 #' @param upper_quantile an optional vector specifying the upper quantile of the hazard ratio. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., `c(0.80, 0.98)`). If only one value is provided, then the PHS scores between that number and Infinite are included. The default is `0.80`. 
 #' @param lower_quantile an optional vector specifying the lower quantile of the hazard ratio. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., `c(0.3, 0.7)`). If only one value is provided, then the PHS scores between -Infinite and that number are included. The default is `0.20`. 
 #' @return A numeric odds ratio
@@ -18,10 +18,10 @@
 #' OR80_20 <- get_hr(data, or_age = 70)
 #' @export
 get_or <- function(data = NULL, 
-                   or_age,
                    phs = "phs", 
                    age = "age", 
                    status = "status", 
+                   or_age,
                    upper_quantile = 0.80, 
                    lower_quantile = 0.20) {  
 

--- a/R/km_curve.R
+++ b/R/km_curve.R
@@ -1,8 +1,12 @@
 #' Return Kaplan-Meier curve
 #'
 #' This function returns a single Kaplan-Meier curve for plotting.
+#' Output includes age, the K-M estimate at each age, and  the upper and lower confidence intervals
 #'
-#' @param data a data.frame containing a column for `phs`, `age`, and `status`
+#' @param data an optional data.frame containing the variables for phs, age, and status
+#' @param phs an optional string specifying the column name in `data` containing the polygenic hazard score for each subject or the unquoted name of a vector containing these values. The default is "phs"
+#' @param age an optional string specifying the column name in `data` containing the age of each subject or the unquoted name of a vector containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation). The default is "age"
+#' @param status an optional string specifying the column name in `data` containing case-control status (0 = censored, 1 = event) or the unquoted name of a vector containing these values. The default is "status"
 #' @param upper a single number specifying the upper end of the quantile. e.g., 1.0
 #' @param lower a single number specifying the lower end of the quantile. e.g., 0.8
 #' @param age_range a vector of ages over which curves should be calculated. Default = 40:100
@@ -13,64 +17,58 @@
 #' @import dplyr
 #' @import ggplot2
 #' @import tibble
-#' @return A ggplot2 plot of a K-M curve
+#' @return A data.frame containing ages, the K-M curve, and the upper and lower confidence intervals
 #' @examples
-#' km_curve <- km_curve(model_file, metadata_file, inverse = TRUE, ideal = FALSE)
+#' km_curve <- km_curve(df, inverse = TRUE, ideal = FALSE)
+#' ggplot(km_curve, aes(x = time,
+#'                      y = estimate,
+#'                      ymin = conf.low,
+#'                      ymax = conf.high)) +
+#'    geom_ribbon() +
+#'    geom_step()
 #' @export
-km_curve <- function(data, upper, lower, age_range = 40:100, scale = FALSE, inverse = FALSE, ideal = FALSE) {
+km_curve <- function(data = NULL,
+                     phs = "phs",
+                     age = "age",
+                     status = "status",
+                     upper,
+                     lower,
+                     age_range = 40:100,
+                     scale = FALSE,
+                     inverse = FALSE,
+                     ideal = FALSE) {
+
   scale <- as.logical(scale)
   inverse <- as.logical(inverse)
-    
-  if (scale) { data$phs <- scale(data$phs, center = TRUE, scale = TRUE) }
-  if (inverse) { data$phs <- data$phs * -1 }
-  
-  critvals <- c(quantile(data$phs, lower), quantile(data$phs, upper))
+  ideal <- as.logical(ideal)
 
-  ix <- which(data$phs >= critvals[1] & data$phs <= critvals[2])
+  if (is.character(phs)) {
+    phs = data[[phs]]
+  }
+  if (is.character(age)) {
+    age = data[[age]]
+  }
+  if (is.character(status)) {
+    status = data[[status]]
+  }
+
+  if (scale) { phs <- scale(phs, center = TRUE, scale = TRUE) }
+  if (inverse) { phs <- phs * -1 }
   
-  cox_model <- coxph(Surv(age, status) ~ phs, data = data)
+  critvals <- c(quantile(phs, lower), quantile(phs, upper))
+
+  ix <- which(phs >= critvals[1] & phs <= critvals[2])
+  
+  tmp_df <- data.frame(age, status, phs)
+
+  cox_model <- coxph(Surv(age, status) ~ phs, data = tmp_df)
   
   bt <- cox_model$coefficients[["phs"]]
   
-  quantile_data <- data[ix, ]
-  
-  median_phs_quantile = quantile(quantile_data$phs, 0.50)
-  median_phs_all <- quantile(data$phs, 0.50)
-
-  #########################
-  # Calculate idealized curves
-  #
-  # Basically copied this from:
-  # https://github.com/cmig-research-group/phs/blob/master/phs_model_example/phs_generate_new_demo.m
-  a <- 0.0700 / 100
-  b <- 0.0753
-  pcainc <- a * exp(b * (age_range - min(age_range))) # this is the population incidence rate for PCa
-  H0 <- a / b * exp(b * (age_range - min(age_range))) # compute baseline hazard
-  H0 <- H0 - H0[1] # assume cumulative hazard == 0 before age 40
-  
-  H <- vector(length = length(H0))
-  S <- vector(length = length(H0))
-
-  H <- H0 * exp(bt * median_phs_quantile - bt * median_phs_all)
-  S <- exp(-H)
-  
-  S_tibble <- as_tibble(S)
-  S_tibble$age_range <- age_range
-  # S_tibble <- S_tibble %>%
-  #   pivot_longer(-agevals, names_to = "percentile")
-  
-  ##########################
+  quantile_data <- tmp_df[ix, ]
   
   # Plot K-M curves for centiles
   mod <- survfit(Surv(age, status) ~ 1, data = quantile_data)
-  
-  tidy_strata <- function(strata) {
-    temp <- c()
-    for (i in seq_along(strata)) {
-      temp <- c(temp, rep_len(names(strata)[i], strata[i]))
-    }
-    temp
-  }
   
   mod_data <- tibble(time = mod$time,
                      n.risk = mod$n.risk,
@@ -81,39 +79,8 @@ km_curve <- function(data, upper, lower, age_range = 40:100, scale = FALSE, inve
                      conf.high = mod$upper,
                      conf.low = mod$lower)
   
-ggplot(mod_data, aes(x = time, y = estimate)) +
-    geom_ribbon(aes(ymin = conf.low, ymax = conf.high),
-                alpha = 0.5) +
-    geom_step() +
-    theme_minimal() +
-    xlim(min(age_range), max(age_range)) + 
-    ylim(0, 1.1) +
-    labs(x = "Age", y = "PCa-free Survival")
-
-  if ( ideal ) {
-    kmcurve = kmcurve + 
-	geom_line(aes(x = age_range, y = value), S_tibble)
-  }
-  kmcurve =
-      select(mod_data, time, estimate, conf.high, conf.low)
+  kmcurve = select(mod_data, time, estimate, conf.high, conf.low)
   return(kmcurve)
   
-#  combined_data <- combined_data %>% 
-#    group_by(status) %>% 
-#    summarize(n = n())
-#  
-#  cases_controls <- tibble(status = combined_data$status, count = combined_data$n)
-#  
-#  ## Hazard ratios
-#  perform <- with(combined_data, 
-#                  RK_get_perf(phs, 
-#                              age, 
-#                              status, 
-#                              ref = phs, 
-#                              swc_popnumcases = cases_controls[2, 2], 
-#                              swc_popnumcontrols = cases_controls[1, 2]))
-#  perform <- stack(perform)[, c(2, 1)]
-#  
-#  write_tsv(perform, paste0(output, model, "_performance.txt"))
 }
 

--- a/R/phs_hist.R
+++ b/R/phs_hist.R
@@ -1,30 +1,50 @@
-#' Plot Histogram of Cases and Control by PHS
+#' Plot Histogram of Cases and Controls by PHS
 #'
 #' This function takes PHS scores and case/control status and plots a histogram.
 #'
-#' @param df Data.frame or tibble containing a column for `phs` and a column for `status`. All other columns ignored.
-#' @param normalize Boolean indicating whether to normalize the histogram to area = 1. This is replaces the y axis with denisty instead of count. Helpful to compare distributions with very different counts. Default = `FALSE`.
+#' @param data an optional data.frame containing the variables for phs, age, and status
+#' @param phs an optional string specifying the column name in `data` containing the polygenic hazard score for each subject or the unquoted name of a vector containing these values. The default is "phs"
+#' @param age an optional string specifying the column name in `data` containing the age of each subject or the unquoted name of a vector containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation). The default is "age"
+#' @param status an optional string specifying the column name in `data` containing case-control status (0 = censored, 1 = event) or the unquoted name of a vector containing these values. The default is "status"
+#' @param normalize Boolean indicating whether to normalize the histogram to area = 1. This replaces the y axis with denisty instead of count. Helpful to compare distributions with very different counts. Default = `FALSE`.
 #' @param scale Boolean indicating whether to center and scale the PHS scores to unit variance. Default = `FALSE`.
 #' @param inverse Boolean indicating whether to inverse (x * -1) the PHS scores to reverse the direction of effect. Default = `FALSE`.
 #' @import ggplot2
 #' @return A ggplot object
 #' @examples
-#' phs_hist <- phs_hist(df)
+#' phs_hist <- phs_hist(df, normalize = TRUE)
 #' @export
-phs_hist <- function(df, normalize = FALSE, scale = FALSE, inverse = FALSE) {
+phs_hist <- function(data = NULL,
+                     phs = "phs",
+                     status = "status",
+                     normalize = FALSE,
+                     scale = FALSE,
+                     inverse = FALSE) {
+  scale <- as.logical(scale)
+  inverse <- as.logical(inverse)
+  normalize <- as.logical(normalize)
 
-  if (scale) { df$phs <- scale(df$phs, center = TRUE, scale = TRUE) }
+  if (is.character(phs)) {
+    phs = data[[phs]]
+  }
+  if (is.character(status)) {
+    status = data[[status]]
+  }
 
-  if (inverse) { df$phs <- df$phs * -1 }
+  if (scale) { phs <- scale(phs, center = TRUE, scale = TRUE) }
+
+  if (inverse) { phs <- phs * -1 }
+
+  tmp_df <- data.frame(status, phs)
 
   if (normalize) {
-    phs_hist = ggplot(df, aes(phs, after_stat(density), fill = as.factor(status))) +
+    phs_hist = ggplot(tmp_df, aes(phs, after_stat(density), fill = as.factor(status))) +
         geom_histogram(binwidth = 0.5, alpha = 0.8, position = "identity") +
       scale_fill_manual(values = c("#132B43", "#56B1F7"), name = "Status") +
         theme_minimal() +
         labs(x = "PHS", y = "Density")
 } else {
-    phs_hist = ggplot(df, aes(phs, fill = status)) +
+    phs_hist = ggplot(tmp_df, aes(phs, fill = as.factor(status))) +
         geom_histogram(binwidth = 0.5, alpha = 0.8, position = "identity") +
         scale_fill_manual(values = c("#132B43", "#56B1F7"), name = "Status") +
         theme_minimal() +

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,7 @@ phs_hist(test_data, normalize = TRUE)
 Then, calculate the hazard ratio comparing the mean of the top 20% of PHSes to the mean of the bottom 20% (i.e., `HR80_20`). Similarly, calculated the odds ratio at age 70 between the top 20% and bottom 20% of PHses.
 
 ```{r}
-HR80_20 = get_hr("phs", "age", "status", data = test_data)
+HR80_20 = get_hr(test_data)
 OR80_20 = get_or(test_data, or_age = 70)
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ calculated the odds ratio at age 70 between the top 20% and bottom 20%
 of PHses.
 
 ``` r
-HR80_20 = get_hr("phs", "age", "status", data = test_data)
+HR80_20 = get_hr(test_data)
 OR80_20 = get_or(test_data, or_age = 70)
 ```
 

--- a/man/get_hr.Rd
+++ b/man/get_hr.Rd
@@ -2,13 +2,13 @@
 % Please edit documentation in R/get_hr.R
 \name{get_hr}
 \alias{get_hr}
-\title{Return hazard ratio for Polygenic Hazard Score}
+\title{Returns a hazard ratio for Polygenic Hazard Scores}
 \usage{
 get_hr(
-  phs,
-  age,
-  status,
   data = NULL,
+  phs = "phs",
+  age = "age",
+  status = "status",
   upper_quantile = 0.8,
   lower_quantile = 0.2,
   swc = FALSE,
@@ -17,17 +17,17 @@ get_hr(
 )
 }
 \arguments{
-\item{phs}{a vector of polygenic hazard scores for subjects or a string specifying the column name in \code{data} containing these values}
+\item{data}{an optional data.frame containing the variables for phs, age, and status}
 
-\item{age}{a vector of ages or a string specifying the column name in \code{data} containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation).}
+\item{phs}{an optional string specifying the column name in \code{data} containing the polygenic hazard score for each subject or the unquoted name of a vector containing these values. The default is "phs"}
 
-\item{status}{a vector of case-control status (0 = censored, 1 = event) or a string specifying the column name in \code{data} containing these values}
+\item{age}{an optional string specifying the column name in \code{data} containing the age of each subject or the unquoted name of a vector containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation). The default is "age"}
 
-\item{data}{an optional data.frame containing the variables phs, age, and status}
+\item{status}{an optional string specifying the column name in \code{data} containing case-control status (0 = censored, 1 = event) or the unquoted name of a vector containing these values. The default is "status"}
 
-\item{upper_quantile}{an optional vector specifying the upper quantile of the hazard ratio. The default is \code{0.80}. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., \code{c(0.80, 0.98)}).}
+\item{upper_quantile}{an optional vector specifying the upper quantile of the hazard ratio. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., \code{c(0.80, 0.98)}). If only one value is provided, then the PHS scores between that number and Infinite are included. The default is \code{0.80}.}
 
-\item{lower_quantile}{an optional vector specifying the lower quantile of the hazard ratio. The default is \code{0.20}. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., \code{c(0.3, 0.7)}).}
+\item{lower_quantile}{an optional vector specifying the lower quantile of the hazard ratio. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., \code{c(0.3, 0.7)}). If only one value is provided, then the PHS scores between -Infinite and that number are included. The default is \code{0.20}.}
 
 \item{swc}{logical. if \code{TRUE} performs sample weight correction}
 
@@ -39,7 +39,11 @@ get_hr(
 A numeric hazard ratio
 }
 \description{
-Return hazard ratio for Polygenic Hazard Score
+This function calculate the hazard ratio.
+The data can either be provided as a data.frame with columns containing
+the phs, age, and status of each individual or separate vectors containing
+each of these values. The columns in \code{data} default to 'phs', 'age', and
+'status', but any arbitrary column names can be used if named explicitly.
 }
 \examples{
 HR80_20 <- get_hr(phs, age, status)

--- a/man/get_or.Rd
+++ b/man/get_or.Rd
@@ -6,10 +6,10 @@
 \usage{
 get_or(
   data = NULL,
-  or_age,
   phs = "phs",
   age = "age",
   status = "status",
+  or_age,
   upper_quantile = 0.8,
   lower_quantile = 0.2
 )
@@ -17,13 +17,13 @@ get_or(
 \arguments{
 \item{data}{an optional data.frame containing the variables for phs, age, and status}
 
-\item{or_age}{an integer specifying the age at which the odds ratio should be calculated}
-
 \item{phs}{an optional string specifying the column name in \code{data} containing the polygenic hazard score for each subject or the unquoted name of a vector containing these values. The default is "phs"}
 
 \item{age}{an optional string specifying the column name in \code{data} containing the age of each subject or the unquoted name of a vector containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation). The default is "age"}
 
 \item{status}{an optional string specifying the column name in \code{data} containing case-control status (0 = censored, 1 = event) or the unquoted name of a vector containing these values. The default is "status"}
+
+\item{or_age}{an integer specifying the age at which the odds ratio should be calculated}
 
 \item{upper_quantile}{an optional vector specifying the upper quantile of the hazard ratio. Can also be supplied as a vector of length 2 to specify both the upper and lower limits of the quantile (e.g., \code{c(0.80, 0.98)}). If only one value is provided, then the PHS scores between that number and Infinite are included. The default is \code{0.80}.}
 

--- a/man/km_curve.Rd
+++ b/man/km_curve.Rd
@@ -5,7 +5,10 @@
 \title{Return Kaplan-Meier curve}
 \usage{
 km_curve(
-  data,
+  data = NULL,
+  phs = "phs",
+  age = "age",
+  status = "status",
   upper,
   lower,
   age_range = 40:100,
@@ -15,7 +18,13 @@ km_curve(
 )
 }
 \arguments{
-\item{data}{a data.frame containing a column for \code{phs}, \code{age}, and \code{status}}
+\item{data}{an optional data.frame containing the variables for phs, age, and status}
+
+\item{phs}{an optional string specifying the column name in \code{data} containing the polygenic hazard score for each subject or the unquoted name of a vector containing these values. The default is "phs"}
+
+\item{age}{an optional string specifying the column name in \code{data} containing the age of each subject or the unquoted name of a vector containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation). The default is "age"}
+
+\item{status}{an optional string specifying the column name in \code{data} containing case-control status (0 = censored, 1 = event) or the unquoted name of a vector containing these values. The default is "status"}
 
 \item{upper}{a single number specifying the upper end of the quantile. e.g., 1.0}
 
@@ -28,11 +37,18 @@ km_curve(
 \item{inverse}{logical. if \code{TRUE} calculates the inverse (x * -1) the PHS scores to reverse the direction of effect. Default = \code{FALSE}.}
 }
 \value{
-A ggplot2 plot of a K-M curve
+A data.frame containing ages, the K-M curve, and the upper and lower confidence intervals
 }
 \description{
 This function returns a single Kaplan-Meier curve for plotting.
+Output includes age, the K-M estimate at each age, and  the upper and lower confidence intervals
 }
 \examples{
-km_curve <- km_curve(model_file, metadata_file, inverse = TRUE, ideal = FALSE)
+km_curve <- km_curve(df, inverse = TRUE, ideal = FALSE)
+ggplot(km_curve, aes(x = time,
+                     y = estimate,
+                     ymin = conf.low,
+                     ymax = conf.high)) +
+   geom_ribbon() +
+   geom_step()
 }

--- a/man/phs_hist.Rd
+++ b/man/phs_hist.Rd
@@ -2,18 +2,31 @@
 % Please edit documentation in R/phs_hist.R
 \name{phs_hist}
 \alias{phs_hist}
-\title{Plot Histogram of Cases and Control by PHS}
+\title{Plot Histogram of Cases and Controls by PHS}
 \usage{
-phs_hist(df, normalize = FALSE, scale = FALSE, inverse = FALSE)
+phs_hist(
+  data = NULL,
+  phs = "phs",
+  status = "status",
+  normalize = FALSE,
+  scale = FALSE,
+  inverse = FALSE
+)
 }
 \arguments{
-\item{df}{Data.frame or tibble containing a column for \code{phs} and a column for \code{status}. All other columns ignored.}
+\item{data}{an optional data.frame containing the variables for phs, age, and status}
 
-\item{normalize}{Boolean indicating whether to normalize the histogram to area = 1. This is replaces the y axis with denisty instead of count. Helpful to compare distributions with very different counts. Default = \code{FALSE}.}
+\item{phs}{an optional string specifying the column name in \code{data} containing the polygenic hazard score for each subject or the unquoted name of a vector containing these values. The default is "phs"}
+
+\item{status}{an optional string specifying the column name in \code{data} containing case-control status (0 = censored, 1 = event) or the unquoted name of a vector containing these values. The default is "status"}
+
+\item{normalize}{Boolean indicating whether to normalize the histogram to area = 1. This replaces the y axis with denisty instead of count. Helpful to compare distributions with very different counts. Default = \code{FALSE}.}
 
 \item{scale}{Boolean indicating whether to center and scale the PHS scores to unit variance. Default = \code{FALSE}.}
 
 \item{inverse}{Boolean indicating whether to inverse (x * -1) the PHS scores to reverse the direction of effect. Default = \code{FALSE}.}
+
+\item{age}{an optional string specifying the column name in \code{data} containing the age of each subject or the unquoted name of a vector containing these values. For cases, this should be the age at event (e.g., diagnosis) and for controls this should be age of censoring (e.g., last observation). The default is "age"}
 }
 \value{
 A ggplot object
@@ -22,5 +35,5 @@ A ggplot object
 This function takes PHS scores and case/control status and plots a histogram.
 }
 \examples{
-phs_hist <- phs_hist(df)
+phs_hist <- phs_hist(df, normalize = TRUE)
 }


### PR DESCRIPTION
This resolves #14 

I decided to use the most flexible option of the three I presented. For each function, the first argument is an optional data.frame which, by default, is assumed to have columns "phs" "status" and "age". So if the user prefers to use these defaults, they can run the command simply by providing a data.frame:

```
get_hr(df)
```

The function will fail if any of these columns are not found.

The user can provide alternative names for these columns if they prefer by specifying them as strings with the `phs`, `age`, and `status` arguments:

```
get_hr(df, phs = "HazardScore", age = "AgeLastObs", status = "CaseControl")
```

A third option is to provide the unquoted names of individual vectors to these arguments instead of providing a data.frame to the `data` argument.

```
get_hr(phs = HazardScore, age = AgeLastObs, status = CaseControl)
```

Lastly, you can combine any of these options together if you like:

```
get_hr(data = df, age = AgeLastObs, status = "CaseControl")
```

In this example, `df` contains a column named "phs" so the `phs` argument is omitted since that's the default, `age` is given a named vector `AgeLastObs` that is not in `df`, and `status` is given a non-standard column name in `df` called "CaseControl".